### PR TITLE
look for right /tmp location.

### DIFF
--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -634,7 +634,7 @@ class GTrends
         }
 
         $client = new Http\Client();
-        $cookieJar = tempnam('/tmp','cookie');
+        $cookieJar = tempnam(sys_get_temp_dir(),'cookie');
         $client->setOptions([
             'adapter' => Http\Client\Adapter\Curl::class,
             'curloptions' => [


### PR DESCRIPTION
Lookup the right temporary directory, Fix Error on Windows & other systems with different tmp path than "/tmp"