### PR TITLE
RELATED_QUERIES_X Error

### DIFF
--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -142,7 +142,7 @@ class GTrends
             $results = [];
             foreach ($widgetsArray as $widget) {
 
-                if ($widget['id'] === 'RELATED_QUERIES') {
+                if (stripos($widget['id'], 'RELATED_QUERIES') !== false) {
 
                     $kWord = $widget['request']['restriction']['complexKeywordsRestriction']['keyword'][0]['value'] ?? null;
                     $relatedPayload['hl'] = $this->options['hl'];


### PR DESCRIPTION
If you use more than a keyword widgets id is in the form RELATED_QUERIES_X (where X is 1,2,3 and so on)
With this modification it is possible to handle that ids.