### PR TITLE
Fix: empty geo when fetching geo map broken

### DIFF
--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -257,7 +257,7 @@ class GTrends
 
                 $interestBySubregionPayload['hl'] = $this->options['hl'];
                 $interestBySubregionPayload['tz'] = $this->options['tz'];
-                $interestBySubregionPayload['req'] = str_replace('geo: []', 'geo: {}', Json\Json::encode($widget['request']));
+                $interestBySubregionPayload['req'] = str_replace('"geo":[]', '"geo":{}', Json\Json::encode($widget['request']));
                 $interestBySubregionPayload['token'] = $widget['token'];
 
                 $data = $this->_getData(self::INTEREST_BY_SUBREGION_ENDPOINT, 'GET', $interestBySubregionPayload);

--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -257,7 +257,7 @@ class GTrends
 
                 $interestBySubregionPayload['hl'] = $this->options['hl'];
                 $interestBySubregionPayload['tz'] = $this->options['tz'];
-                $interestBySubregionPayload['req'] = str_replace('[]', '{}', Json\Json::encode($widget['request']));
+                $interestBySubregionPayload['req'] = str_replace('geo: []', '{}', Json\Json::encode($widget['request']));
                 $interestBySubregionPayload['token'] = $widget['token'];
 
                 $data = $this->_getData(self::INTEREST_BY_SUBREGION_ENDPOINT, 'GET', $interestBySubregionPayload);

--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -257,7 +257,7 @@ class GTrends
 
                 $interestBySubregionPayload['hl'] = $this->options['hl'];
                 $interestBySubregionPayload['tz'] = $this->options['tz'];
-                $interestBySubregionPayload['req'] = str_replace('geo: []', '{}', Json\Json::encode($widget['request']));
+                $interestBySubregionPayload['req'] = str_replace('geo: []', 'geo: {}', Json\Json::encode($widget['request']));
                 $interestBySubregionPayload['token'] = $widget['token'];
 
                 $data = $this->_getData(self::INTEREST_BY_SUBREGION_ENDPOINT, 'GET', $interestBySubregionPayload);

--- a/src/Google/GTrends.php
+++ b/src/Google/GTrends.php
@@ -257,7 +257,7 @@ class GTrends
 
                 $interestBySubregionPayload['hl'] = $this->options['hl'];
                 $interestBySubregionPayload['tz'] = $this->options['tz'];
-                $interestBySubregionPayload['req'] = Json\Json::encode($widget['request']);
+                $interestBySubregionPayload['req'] = str_replace('[]', '{}', Json\Json::encode($widget['request']));
                 $interestBySubregionPayload['token'] = $widget['token'];
 
                 $data = $this->_getData(self::INTEREST_BY_SUBREGION_ENDPOINT, 'GET', $interestBySubregionPayload);


### PR DESCRIPTION
To reproduce bug:

```PHP
use Google\GTrends;
$options = [ 'hl'  => 'sv', 'tz'  => -60, 'geo' => ''];
$gt = new GTrends($options);
$r = $gt->explore(['foo', 'bar'], time: 'today 5-y');
```
Apparently, Google doesn't adhere to standards since ```geo:[]``` isn't appreciated and only accepts ```geo:{}```.
This PR replaces, after json encoding, geo:[] with geo:{}.

Open for feedback.